### PR TITLE
Switch one PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/dlmlpl.cpp
+++ b/src/dlmlpl.cpp
@@ -103,7 +103,7 @@ arma::rowvec dlmLplCpp(NumericVector Yt_, NumericMatrix Ft_, double delta, doubl
     
     // Log Predictive Likelihood 
     // in the original R code the asignment was to lpl(t) and the first values was discarded, so we use here lpl(t-1)
-    lpl(t-1) = lgamma((nt(t-1)+1)/2)-lgamma(nt(t-1)/2)-0.5*log(PI*nt(t-1)*Qt(t))-((nt(t-1)+1)/2)*log(1+(1/nt(t-1))*(et*et)/Qt(t));
+    lpl(t-1) = lgamma((nt(t-1)+1)/2)-lgamma(nt(t-1)/2)-0.5*log(M_PI*nt(t-1)*Qt(t))-((nt(t-1)+1)/2)*log(1+(1/nt(t-1))*(et*et)/Qt(t));
   }
   
   // Debug print to console


### PR DESCRIPTION
Dear DGM team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history. 

Your package uses PI (instead of the standard C define M_PI, or the newer Armadillo constant arma::datum::pi) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do.   We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.